### PR TITLE
refactor: UI 重構 — 共用元件、效能優化、React 最佳實踐

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // PM2 config (must use CommonJS)
     "ecosystem.config.js",
+    // Coverage report (auto-generated)
+    "coverage/**",
   ]),
 ]);
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -16,7 +16,7 @@ export default function RootError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">發生錯誤</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/favorites/FavoritesContent.tsx
+++ b/src/app/favorites/FavoritesContent.tsx
@@ -2,48 +2,52 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { useState } from 'react';
 import { Heart, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import TiltCard from '@/components/TiltCard';
+import { PageHeader } from '@/components/PageHeader';
+import { cn } from '@/lib/utils';
+import dynamic from 'next/dynamic';
+const TiltCard = dynamic(() => import('@/components/TiltCard'), { ssr: false });
 import { useFavorites } from '@/lib/hooks/useFavorites';
 import { useHistory } from '@/lib/hooks/useHistory';
 import { useFavoritesUpdateCheck } from '@/lib/hooks/useFavoritesUpdateCheck';
 import { getProxiedImageUrl } from '@/lib/image-utils';
-import { STAGGER_DELAY } from '@/lib/constants';
+import { STAGGER_DELAY, DENSE_GRID_CLASS } from '@/lib/constants';
+import { EmptyState } from '@/components/EmptyState';
+import { Spinner } from '@/components/Spinner';
 
 export default function FavoritesContent() {
+  const [editMode, setEditMode] = useState(false);
   const { favorites, isLoaded, removeFavorite } = useFavorites();
   const { history } = useHistory();
   const { newChapterIds } = useFavoritesUpdateCheck(favorites, history, isLoaded);
 
   return (
-    <div className="min-h-screen bg-background">
-
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <div className="mb-6 flex items-center gap-3">
-          <Heart className="h-6 w-6 text-foreground" />
-          <h1 className="text-2xl font-serif font-medium">我的收藏</h1>
-          {isLoaded && favorites.length > 0 && (
-            <span className="text-sm text-muted-foreground">
-              ({favorites.length} 部)
-            </span>
-          )}
-        </div>
+    <main className="mx-auto max-w-7xl px-4 pb-8">
+        <PageHeader
+          icon={Heart}
+          title="我的收藏"
+          count={isLoaded ? favorites.length : undefined}
+          actions={
+            isLoaded && favorites.length > 0 ? (
+              <Button
+                variant={editMode ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => setEditMode(!editMode)}
+              >
+                {editMode ? '完成' : '管理'}
+              </Button>
+            ) : undefined
+          }
+        />
 
         {!isLoaded ? (
-          <div className="flex items-center justify-center py-20">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-foreground border-t-transparent" />
-          </div>
+          <Spinner />
         ) : favorites.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
-            <Heart className="h-16 w-16 text-muted-foreground/30" />
-            <p className="text-lg text-muted-foreground">尚無收藏</p>
-            <Button asChild variant="outline">
-              <Link href="/">探索漫畫</Link>
-            </Button>
-          </div>
+          <EmptyState icon={Heart} message="尚無收藏" actionLabel="探索漫畫" actionHref="/" />
         ) : (
-          <div className="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8">
+          <div className={DENSE_GRID_CLASS}>
             {favorites.map((item, index) => (
               <div key={item.mangaId} className="group relative">
                 <Link href={`/manga/${item.mangaId}`}>
@@ -75,19 +79,21 @@ export default function FavoritesContent() {
                 <Button
                   variant="destructive"
                   size="icon"
-                  className="absolute right-1 top-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                  className={cn(
+                    'absolute right-1 top-1 h-7 w-7 transition-opacity',
+                    editMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                  )}
                   onClick={(e) => {
                     e.preventDefault();
                     removeFavorite(item.mangaId);
                   }}
                 >
-                  <Trash2 className="h-3 w-3" />
+                  <Trash2 className="h-3.5 w-3.5" />
                 </Button>
               </div>
             ))}
           </div>
         )}
       </main>
-    </div>
   );
 }

--- a/src/app/favorites/error.tsx
+++ b/src/app/favorites/error.tsx
@@ -16,7 +16,7 @@ export default function FavoritesError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">載入收藏失敗</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/favorites/loading.tsx
+++ b/src/app/favorites/loading.tsx
@@ -1,23 +1,22 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import { DENSE_GRID_CLASS } from '@/lib/constants';
 
-export default function FavoritesLoading() {
+export default function Loading() {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8">
-        {/* 標題骨架 */}
-        <Skeleton className="mb-6 h-8 w-24" />
-
-        {/* 收藏列表骨架 */}
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {Array.from({ length: 10 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
-              <Skeleton className="aspect-[2/3] w-full rounded-lg" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-3 w-1/2" />
+    <main className="mx-auto max-w-7xl px-4 py-8">
+        <div className="mb-6 flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-lg" />
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-7 w-24" />
+        </div>
+        <div className={DENSE_GRID_CLASS}>
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="space-y-1">
+              <Skeleton className="aspect-[3/4] w-full rounded-lg" />
+              <Skeleton className="h-3 w-3/4" />
             </div>
           ))}
         </div>
-      </div>
-    </div>
+      </main>
   );
 }

--- a/src/app/history/HistoryContent.tsx
+++ b/src/app/history/HistoryContent.tsx
@@ -2,15 +2,21 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Clock, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import TiltCard from '@/components/TiltCard';
+import { PageHeader } from '@/components/PageHeader';
+import { cn } from '@/lib/utils';
+import dynamic from 'next/dynamic';
+const TiltCard = dynamic(() => import('@/components/TiltCard'), { ssr: false });
 import { useHistory } from '@/lib/hooks/useHistory';
 import { getProxiedImageUrl } from '@/lib/image-utils';
-import { STAGGER_DELAY } from '@/lib/constants';
+import { STAGGER_DELAY, DENSE_GRID_CLASS } from '@/lib/constants';
+import { EmptyState } from '@/components/EmptyState';
+import { Spinner } from '@/components/Spinner';
 
 export default function HistoryContent() {
+  const [editMode, setEditMode] = useState(false);
   const { history, isLoaded, removeHistory, clearHistory } = useHistory();
 
   // 每部漫畫只顯示最新一筆（history 已按 timestamp desc 排序）
@@ -24,40 +30,35 @@ export default function HistoryContent() {
   }, [history]);
 
   return (
-    <div className="min-h-screen bg-background">
-
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Clock className="h-6 w-6 text-foreground" />
-            <h1 className="text-2xl font-serif font-medium">閱讀歷史</h1>
-            {isLoaded && deduped.length > 0 && (
-              <span className="text-sm text-muted-foreground">
-                ({deduped.length} 部)
-              </span>
-            )}
-          </div>
-          {isLoaded && deduped.length > 0 && (
-            <Button variant="ghost" size="sm" onClick={clearHistory}>
-              清除全部
-            </Button>
-          )}
-        </div>
+    <main className="mx-auto max-w-7xl px-4 pb-8">
+        <PageHeader
+          icon={Clock}
+          title="閱讀歷史"
+          count={isLoaded ? deduped.length : undefined}
+          actions={
+            isLoaded && deduped.length > 0 ? (
+              <>
+                <Button
+                  variant={editMode ? 'default' : 'ghost'}
+                  size="sm"
+                  onClick={() => setEditMode(!editMode)}
+                >
+                  {editMode ? '完成' : '管理'}
+                </Button>
+                <Button variant="ghost" size="sm" onClick={clearHistory}>
+                  清除全部
+                </Button>
+              </>
+            ) : undefined
+          }
+        />
 
         {!isLoaded ? (
-          <div className="flex items-center justify-center py-20">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-foreground border-t-transparent" />
-          </div>
+          <Spinner />
         ) : deduped.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
-            <Clock className="h-16 w-16 text-muted-foreground/30" />
-            <p className="text-lg text-muted-foreground">尚無閱讀記錄</p>
-            <Button asChild variant="outline">
-              <Link href="/">探索漫畫</Link>
-            </Button>
-          </div>
+          <EmptyState icon={Clock} message="尚無閱讀記錄" actionLabel="探索漫畫" actionHref="/" />
         ) : (
-          <div className="grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8">
+          <div className={DENSE_GRID_CLASS}>
             {deduped.map((item, index) => (
               <div key={`${item.mangaId}-${item.chapterId}`} className="group relative">
                 <Link
@@ -92,19 +93,21 @@ export default function HistoryContent() {
                 <Button
                   variant="destructive"
                   size="icon"
-                  className="absolute right-1 top-1 h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                  className={cn(
+                    'absolute right-1 top-1 h-7 w-7 transition-opacity',
+                    editMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                  )}
                   onClick={(e) => {
                     e.preventDefault();
                     removeHistory(item.mangaId);
                   }}
                 >
-                  <Trash2 className="h-3 w-3" />
+                  <Trash2 className="h-3.5 w-3.5" />
                 </Button>
               </div>
             ))}
           </div>
         )}
       </main>
-    </div>
   );
 }

--- a/src/app/history/error.tsx
+++ b/src/app/history/error.tsx
@@ -16,7 +16,7 @@ export default function HistoryError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">載入閱讀紀錄失敗</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/history/loading.tsx
+++ b/src/app/history/loading.tsx
@@ -1,26 +1,22 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import { DENSE_GRID_CLASS } from '@/lib/constants';
 
-export default function HistoryLoading() {
+export default function Loading() {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8">
-        {/* 標題骨架 */}
-        <Skeleton className="mb-6 h-8 w-32" />
-
-        {/* 閱讀紀錄列表骨架 */}
-        <div className="flex flex-col gap-3">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-4 rounded-lg border p-3">
-              <Skeleton className="h-16 w-12 flex-shrink-0 rounded" />
-              <div className="flex-1 space-y-2">
-                <Skeleton className="h-4 w-3/4" />
-                <Skeleton className="h-3 w-1/2" />
-                <Skeleton className="h-3 w-1/3" />
-              </div>
+    <main className="mx-auto max-w-7xl px-4 py-8">
+        <div className="mb-6 flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-lg" />
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-7 w-24" />
+        </div>
+        <div className={DENSE_GRID_CLASS}>
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="space-y-1">
+              <Skeleton className="aspect-[3/4] w-full rounded-lg" />
+              <Skeleton className="h-3 w-3/4" />
             </div>
           ))}
         </div>
-      </div>
-    </div>
+      </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Navbar } from "@/components/Navbar";
-import { SnowEffect } from "@/components/SnowEffect";
+import { SnowEffectLoader } from "@/components/SnowEffectLoader";
 import "./globals.css";
 
 const inter = Inter({
@@ -35,9 +35,9 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         <ThemeProvider>
-          <SnowEffect />
+          <SnowEffectLoader />
           <Navbar />
-          {children}
+          <main className="min-h-screen bg-background text-foreground pt-20">{children}</main>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -2,8 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function HomeLoading() {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8">
+    <div className="mx-auto max-w-7xl px-4 py-8">
         {/* 搜尋列骨架 */}
         <Skeleton className="mb-6 h-10 w-full max-w-md" />
 
@@ -24,7 +23,6 @@ export default function HomeLoading() {
             </div>
           ))}
         </div>
-      </div>
     </div>
   );
 }

--- a/src/app/manga/[id]/MangaDetailContent.tsx
+++ b/src/app/manga/[id]/MangaDetailContent.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { MangaInfo } from '@/lib/scraper/types';
@@ -18,11 +19,11 @@ import MangaActions from './MangaActions';
 
 function LoadingSkeleton() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="-mt-20">
       <div className="relative h-[60vh] min-h-[500px]">
         <div className="absolute inset-0 bg-muted" />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-transparent" />
-        <div className="relative mx-auto flex h-full max-w-7xl flex-col items-center gap-8 px-4 pt-20 md:flex-row md:items-end md:pb-12">
+        <div className="relative mx-auto flex h-full max-w-7xl flex-col items-center gap-8 px-4 pt-40 md:flex-row md:items-end md:pb-12">
           <Skeleton className="h-72 w-48 flex-shrink-0 rounded-lg md:h-80 md:w-56" />
           <div className="flex-1 space-y-4 pb-8">
             <Skeleton className="h-10 w-3/4" />
@@ -57,6 +58,7 @@ interface MangaDetailContentProps {
  * 漫畫詳情頁內容（Client Component）
  */
 export default function MangaDetailContent({ id, initialData }: MangaDetailContentProps) {
+  const router = useRouter();
   const { data: manga, loading, error } = useFetch<MangaInfo>(
     initialData ? null : `/api/manga/${id}`,
     [id],
@@ -97,10 +99,10 @@ export default function MangaDetailContent({ id, initialData }: MangaDetailConte
   const coverUrl = getProxiedImageUrl(manga.cover);
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <>
       {/* Hero 區域 - 負 margin 讓背景延伸到 navbar 後方 */}
-      <div className="relative -mt-20 min-h-[60vh] overflow-hidden pt-20">
-        <div className="absolute inset-0 -top-20">
+      <div className="relative -mt-40 min-h-[60vh] overflow-hidden pt-40">
+        <div className="absolute inset-0 -top-40">
           <Image
             src={coverUrl}
             alt=""
@@ -109,16 +111,14 @@ export default function MangaDetailContent({ id, initialData }: MangaDetailConte
             unoptimized
             priority
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-background/30" />
+          <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-background/60" />
           <div className="absolute inset-0 bg-gradient-to-r from-background/50 via-transparent to-background/50" />
         </div>
 
         <div className="relative z-10 mx-auto max-w-7xl px-4 pt-6">
-          <Button asChild variant="ghost" size="sm" className="gap-2">
-            <Link href="/">
-              <ArrowLeft className="h-4 w-4" />
-              返回首頁
-            </Link>
+          <Button variant="ghost" size="sm" className="gap-2" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+            返回
           </Button>
         </div>
 
@@ -158,7 +158,7 @@ export default function MangaDetailContent({ id, initialData }: MangaDetailConte
       </div>
 
       <main className="mx-auto max-w-7xl px-4 py-8">
-        <h2 className="text-xl font-serif font-medium">章節列表</h2>
+        <h2 className="text-2xl font-serif font-medium">章節列表</h2>
         {manga.chapters.length === 0 ? (
           <p className="mt-4 text-muted-foreground">沒有章節</p>
         ) : (
@@ -173,6 +173,6 @@ export default function MangaDetailContent({ id, initialData }: MangaDetailConte
           ))
         )}
       </main>
-    </div>
+    </>
   );
 }

--- a/src/app/manga/[id]/error.tsx
+++ b/src/app/manga/[id]/error.tsx
@@ -16,7 +16,7 @@ export default function MangaDetailError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">載入漫畫詳情失敗</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/manga/[id]/loading.tsx
+++ b/src/app/manga/[id]/loading.tsx
@@ -2,10 +2,10 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function MangaDetailLoading() {
   return (
-    <div className="min-h-screen bg-background">
+    <>
       {/* Hero 骨架 */}
-      <div className="relative -mt-20 min-h-[60vh] overflow-hidden pt-20">
-        <div className="absolute inset-0 -top-20 bg-muted" />
+      <div className="relative -mt-40 min-h-[60vh] overflow-hidden pt-40">
+        <div className="absolute inset-0 -top-40 bg-muted" />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-transparent" />
 
         {/* 返回按鈕 */}
@@ -40,6 +40,6 @@ export default function MangaDetailLoading() {
         <Skeleton className="mb-4 h-8 w-24" />
         <Skeleton className="h-12 w-full rounded-lg" />
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import { FileQuestion } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
+      <FileQuestion className="h-12 w-12 text-muted-foreground" />
+      <h2 className="text-xl font-serif font-medium">找不到頁面</h2>
+      <p className="max-w-md text-center text-sm text-muted-foreground">
+        您要找的頁面不存在或已被移除
+      </p>
+      <Button asChild>
+        <Link href="/">返回首頁</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,31 @@
 'use client';
 
-import { useState, useEffect, Suspense, useMemo } from 'react';
+import { useState, useEffect, useRef, Suspense, useMemo, startTransition } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import MangaCard from '@/components/MangaCard';
 import type { FilterState } from '@/lib/filter-types';
+import { hasActiveFilters } from '@/lib/filter-types';
 import HistorySection from '@/components/HistorySection';
 import FavoritesSection from '@/components/FavoritesSection';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Search, Loader2 } from 'lucide-react';
 import type { MangaListItem, PaginationInfo } from '@/lib/scraper/types';
 import { STAGGER_DELAY } from '@/lib/constants';
 import { parseFiltersFromParams, STATUS_MAP, SORT_MAP } from '@/lib/filter-utils';
+
+function MangaGridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="aspect-3/4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 /**
  * 首頁內容元件
@@ -26,6 +41,8 @@ function HomeContent() {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [page, setPage] = useState(1);
+
+  const loaderRef = useRef<HTMLDivElement>(null);
 
   // 從 URL 解析 filter 狀態
   const filters = useMemo(
@@ -119,6 +136,25 @@ function HomeContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, keywordFromUrl]);
 
+  // IntersectionObserver 無限滾動
+  useEffect(() => {
+    if (!loaderRef.current || loading || loadingMore) return;
+    if (pagination && page >= pagination.total) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !loadingMore) {
+          loadMore();
+        }
+      },
+      { threshold: 0.1, rootMargin: '200px' }
+    );
+
+    observer.observe(loaderRef.current);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, pagination, loading, loadingMore]);
+
   /**
    * 載入更多
    */
@@ -132,81 +168,102 @@ function HomeContent() {
    * 清除搜尋
    */
   const clearSearch = () => {
-    router.push('/');
+    startTransition(() => {
+      router.push('/');
+    });
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <>
       {/* Main Content */}
-      <main className="mx-auto max-w-7xl px-4 pb-8 pt-20">
+      <main className="mx-auto max-w-7xl px-4 pb-8">
         {/* 搜尋結果提示 */}
         {keywordFromUrl && (
-          <div className="mb-6 flex items-center gap-2 rounded-lg border border-border bg-card p-4">
+          <div className="mb-6 flex items-center gap-3 rounded-lg border border-primary/20 bg-primary/5 p-4">
+            <Search className="h-5 w-5 text-primary" />
             <span className="text-muted-foreground">
-              搜尋結果：
-              <span className="font-medium text-foreground">
-                {keywordFromUrl}
-              </span>
+              搜尋：
+              <span className="font-medium text-foreground">{keywordFromUrl}</span>
+              {pagination && (
+                <span className="ml-2">（{pagination.totalItems} 部結果）</span>
+              )}
             </span>
-            <Button variant="link" size="sm" onClick={clearSearch}>
-              清除搜尋
+            <Button variant="ghost" size="sm" onClick={clearSearch} className="ml-auto">
+              清除
             </Button>
           </div>
         )}
 
         {/* 我的收藏 & 最近閱讀 */}
         {!keywordFromUrl && (
-          <div className="mb-8 flex flex-col gap-8 lg:flex-row lg:gap-12">
+          <div className="mb-12 flex flex-col gap-8 lg:flex-row lg:gap-12">
             <FavoritesSection />
             <HistorySection />
           </div>
         )}
 
-        {loading ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-            {Array.from({ length: 12 }).map((_, i) => (
-              <div key={i} className="space-y-2">
-                <Skeleton className="aspect-3/4 w-full rounded-lg" />
-                <Skeleton className="h-4 w-3/4" />
-              </div>
-            ))}
-          </div>
-        ) : mangas.length === 0 ? (
-          <div className="flex h-64 items-center justify-center">
-            <div className="text-xl text-muted-foreground">沒有找到漫畫</div>
-          </div>
-        ) : (
-          <>
-            {/* Manga Grid with staggered entrance */}
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-              {mangas.map((manga, index) => (
-                <MangaCard
-                  key={manga.id}
-                  manga={manga}
-                  animationDelay={index * STAGGER_DELAY}
-                />
-              ))}
-            </div>
-
-            {/* Load More */}
-            {pagination && page < pagination.total && (
-              <div className="mt-8 flex flex-col items-center gap-2">
-                <Button
-                  onClick={loadMore}
-                  disabled={loadingMore}
-                  className="px-8 py-3 font-medium"
-                >
-                  {loadingMore ? '載入中...' : '載入更多'}
-                </Button>
+        {/* 分隔線 + 主要漫畫區塊 */}
+        <div className={!keywordFromUrl ? 'border-t border-border pt-8' : ''}>
+          {/* 區塊標題 */}
+          {!keywordFromUrl && (
+            <div className="mb-6 flex items-center justify-between">
+              <h2 className="text-xl font-serif font-medium">
+                {hasActiveFilters(filters) ? '篩選結果' : '所有漫畫'}
+              </h2>
+              {pagination && (
                 <span className="text-sm text-muted-foreground">
-                  已顯示 {mangas.length} / {pagination.totalItems} 部漫畫
+                  共 {pagination.totalItems} 部
                 </span>
+              )}
+            </div>
+          )}
+
+          <div aria-live="polite">
+            {loading ? (
+              <MangaGridSkeleton />
+            ) : mangas.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+                <Search className="h-16 w-16 text-muted-foreground/30" />
+                <p className="text-lg text-muted-foreground">沒有找到符合條件的漫畫</p>
+                {keywordFromUrl ? (
+                  <Button onClick={clearSearch} variant="outline">清除搜尋</Button>
+                ) : hasActiveFilters(filters) ? (
+                  <Button onClick={() => { startTransition(() => { router.push('/'); }); }} variant="outline">清除篩選</Button>
+                ) : null}
               </div>
+            ) : (
+              <>
+                {/* Manga Grid with staggered entrance */}
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                  {mangas.map((manga, index) => (
+                    <MangaCard
+                      key={manga.id}
+                      manga={manga}
+                      animationDelay={Math.min(index, 12) * STAGGER_DELAY}
+                    />
+                  ))}
+                </div>
+
+                {/* Infinite scroll loader */}
+                <div ref={loaderRef} className="flex h-20 items-center justify-center">
+                  {loadingMore && (
+                    <div className="flex items-center gap-2 text-muted-foreground">
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>載入更多...</span>
+                    </div>
+                  )}
+                  {pagination && page >= pagination.total && mangas.length > 0 && (
+                    <p className="text-sm text-muted-foreground">
+                      已顯示全部 {pagination.totalItems} 部漫畫
+                    </p>
+                  )}
+                </div>
+              </>
             )}
-          </>
-        )}
+          </div>
+        </div>
       </main>
-    </div>
+    </>
   );
 }
 
@@ -218,17 +275,8 @@ export default function Home() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-background">
-          <div className="mx-auto max-w-7xl px-4 pb-8 pt-20">
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-              {Array.from({ length: 12 }).map((_, i) => (
-                <div key={i} className="space-y-2">
-                  <Skeleton className="aspect-3/4 w-full rounded-lg" />
-                  <Skeleton className="h-4 w-3/4" />
-                </div>
-              ))}
-            </div>
-          </div>
+        <div className="mx-auto max-w-7xl px-4 pb-8">
+          <MangaGridSkeleton />
         </div>
       }
     >

--- a/src/app/rank/RankContent.tsx
+++ b/src/app/rank/RankContent.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { useState, useRef, useLayoutEffect } from 'react';
-import Link from 'next/link';
+import React, { useState, useRef, useLayoutEffect, memo } from 'react';
 import Image from 'next/image';
 import { ArrowUp, ArrowDown, Minus, Eye, Trophy, Crown, Medal } from 'lucide-react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { PageHeader } from '@/components/PageHeader';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { RankItem } from '@/lib/scraper/types';
 import { RankTrend } from '@/lib/scraper/types';
 import { getProxiedImageUrl } from '@/lib/image-utils';
 import { useFetch } from '@/lib/hooks/useFetch';
+import { EmptyState } from '@/components/EmptyState';
 
 /** 榜單類型 */
 enum RankType {
@@ -109,7 +111,7 @@ function TrendIndicator({ trend }: { trend?: RankTrend }) {
 /**
  * 排行榜項目卡片元件
  */
-function RankItemCard({ item, animationDelay = 0 }: RankItemCardProps) {
+const RankItemCard = memo(function RankItemCard({ item, animationDelay = 0 }: RankItemCardProps) {
   const coverUrl = getProxiedImageUrl(item.cover);
 
   const isTopThree = item.rank <= 3;
@@ -184,7 +186,7 @@ function RankItemCard({ item, animationDelay = 0 }: RankItemCardProps) {
       </div>
     </Link>
   );
-}
+});
 
 /**
  * 排行榜互動內容
@@ -223,25 +225,11 @@ export default function RankContent() {
   }, [rankType]);
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <>
       {/* Header */}
-      <header className="border-b border-border bg-background">
-        <div className="mx-auto max-w-4xl px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Link
-                href="/"
-                className="text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <span className="text-lg">&larr;</span>
-              </Link>
-              <h1 className="flex items-center gap-2 text-2xl font-serif font-medium">
-                <Trophy className="h-6 w-6 text-foreground" />
-                排行榜
-              </h1>
-            </div>
-          </div>
-
+      <div className="border-b border-border bg-background">
+        <div className="mx-auto max-w-5xl px-4 py-4">
+          <PageHeader icon={Trophy} title="排行榜" />
           {/* 榜單類型切換 */}
           <div className="relative mt-4 flex gap-1">
             {/* 滑動指示器 */}
@@ -264,8 +252,8 @@ export default function RankContent() {
                 size="sm"
                 className={`flex-1 rounded-lg transition-all duration-200 sm:flex-none sm:px-6 ${
                   rankType === type.id
-                    ? 'bg-accent text-foreground'
-                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    ? 'text-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {type.name}
@@ -273,41 +261,44 @@ export default function RankContent() {
             ))}
           </div>
         </div>
-      </header>
+      </div>
 
       {/* Main Content */}
-      <main className="mx-auto max-w-4xl px-4 py-6">
-        {loading ? (
-          <div className="space-y-4">
-            {Array.from({ length: 10 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-4 rounded-xl p-4">
-                <Skeleton className="h-12 w-12 rounded-full" />
-                <Skeleton className="h-20 w-14 rounded-lg" />
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-5 w-1/3" />
-                  <Skeleton className="h-4 w-1/4" />
-                  <Skeleton className="h-4 w-1/2" />
+      <main className="mx-auto max-w-5xl px-4 py-6">
+        <div aria-live="polite">
+          {loading ? (
+            <div className="space-y-4">
+              {Array.from({ length: 10 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-4 rounded-xl p-4">
+                  <Skeleton className="h-12 w-12 rounded-full" />
+                  <Skeleton className="h-20 w-14 rounded-lg" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-5 w-1/3" />
+                    <Skeleton className="h-4 w-1/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        ) : rankList.length === 0 ? (
-          <div className="flex h-64 flex-col items-center justify-center gap-4">
-            <Trophy className="h-16 w-16 text-muted-foreground/50" />
-            <p className="text-xl text-muted-foreground">暫無排行數據</p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {rankList.map((item, index) => (
-              <RankItemCard
-                key={item.id}
-                item={item}
-                animationDelay={index * 50}
-              />
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          ) : rankList.length === 0 ? (
+            <EmptyState icon={Trophy} message="暫無排行數據" />
+          ) : (
+            <div className="space-y-2">
+              {rankList.map((item, index) => (
+                <React.Fragment key={item.id}>
+                  {item.rank === 4 && (
+                    <div className="my-4 border-t border-border/50" />
+                  )}
+                  <RankItemCard
+                    item={item}
+                    animationDelay={index * 50}
+                  />
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </div>
       </main>
-    </div>
+    </>
   );
 }

--- a/src/app/rank/error.tsx
+++ b/src/app/rank/error.tsx
@@ -16,7 +16,7 @@ export default function RankError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">載入排行榜失敗</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/rank/loading.tsx
+++ b/src/app/rank/loading.tsx
@@ -2,8 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function RankLoading() {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className="mx-auto max-w-4xl px-4 py-8">
         {/* 標題骨架 */}
         <Skeleton className="mb-6 h-8 w-24" />
 
@@ -29,6 +28,5 @@ export default function RankLoading() {
           ))}
         </div>
       </div>
-    </div>
   );
 }

--- a/src/app/read/[bid]/[cid]/ReaderContent.tsx
+++ b/src/app/read/[bid]/[cid]/ReaderContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import Reader from '@/components/reader';
+import dynamic from 'next/dynamic';
+const Reader = dynamic(() => import('@/components/reader'), { ssr: false });
 import type { ChapterData } from '@/components/reader/types';
 
 interface ReaderContentProps {

--- a/src/app/read/[bid]/[cid]/error.tsx
+++ b/src/app/read/[bid]/[cid]/error.tsx
@@ -20,7 +20,7 @@ export default function ReaderError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 px-4 text-white">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 px-4 text-white" role="alert">
       <AlertCircle className="h-12 w-12 text-red-500" />
       <h2 className="text-xl font-serif font-medium">載入章節失敗</h2>
       <p className="max-w-md text-center text-sm text-zinc-400">{error.message}</p>

--- a/src/app/update/UpdateContent.tsx
+++ b/src/app/update/UpdateContent.tsx
@@ -3,11 +3,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, Clock, Calendar, Loader2 } from 'lucide-react';
+import { Clock, Calendar, Loader2, Sparkles } from 'lucide-react';
+import { PageHeader } from '@/components/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import TiltCard from '@/components/TiltCard';
+import dynamic from 'next/dynamic';
+const TiltCard = dynamic(() => import('@/components/TiltCard'), { ssr: false });
 import type { MangaListItem, PaginationInfo } from '@/lib/scraper/types';
 import { getProxiedImageUrl } from '@/lib/image-utils';
 import { STAGGER_DELAY } from '@/lib/constants';
@@ -302,71 +304,61 @@ export default function UpdateContent() {
   let runningIndex = 0;
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <>
       {/* Header */}
-      <header className="border-b border-border bg-background">
+      <div className="border-b border-border bg-background">
         <div className="mx-auto max-w-7xl px-4 py-4">
-          <div className="flex items-center gap-4">
-            <Link href="/">
-              <Button variant="ghost" size="icon" className="shrink-0">
-                <ArrowLeft className="h-5 w-5" />
-              </Button>
-            </Link>
-            <div>
-              <h1 className="text-xl font-serif font-medium text-foreground">最新更新</h1>
-              <p className="text-sm text-muted-foreground">
-                追蹤最新漫畫章節
-              </p>
-            </div>
-          </div>
+          <PageHeader icon={Sparkles} title="最新更新" subtitle="追蹤最新漫畫章節" />
         </div>
-      </header>
+      </div>
 
       {/* Main Content */}
       <main className="mx-auto max-w-7xl px-4 py-8">
-        {loading ? (
-          <LoadingSkeleton />
-        ) : error ? (
-          <div className="flex h-64 flex-col items-center justify-center gap-4">
-            <p className="text-lg text-muted-foreground">{error}</p>
-            <Button onClick={() => fetchMangas(1, false)}>重試</Button>
-          </div>
-        ) : mangas.length === 0 ? (
-          <div className="flex h-64 items-center justify-center">
-            <p className="text-lg text-muted-foreground">沒有更新資料</p>
-          </div>
-        ) : (
-          <>
-            {/* 日期分組列表 */}
-            {[DateGroup.TODAY, DateGroup.YESTERDAY, DateGroup.EARLIER].map((group) => {
-              const groupMangas = groupedMangas.get(group) || [];
-              const section = (
-                <DateGroupSection
-                  key={group}
-                  group={group}
-                  mangas={groupMangas}
-                  baseIndex={runningIndex}
-                />
-              );
-              runningIndex += groupMangas.length;
-              return section;
-            })}
-
-            {/* 無限滾動觸發器 */}
-            <div ref={loaderRef} className="flex h-20 items-center justify-center">
-              {loadingMore && (
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  <span>載入更多...</span>
-                </div>
-              )}
-              {pagination && page >= pagination.total && mangas.length > 0 && (
-                <p className="text-sm text-muted-foreground">已載入全部更新</p>
-              )}
+        <div aria-live="polite">
+          {loading ? (
+            <LoadingSkeleton />
+          ) : error ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-4">
+              <p className="text-lg text-muted-foreground">{error}</p>
+              <Button onClick={() => fetchMangas(1, false)}>重試</Button>
             </div>
-          </>
-        )}
+          ) : mangas.length === 0 ? (
+            <div className="flex h-64 items-center justify-center">
+              <p className="text-lg text-muted-foreground">沒有更新資料</p>
+            </div>
+          ) : (
+            <>
+              {/* 日期分組列表 */}
+              {[DateGroup.TODAY, DateGroup.YESTERDAY, DateGroup.EARLIER].map((group) => {
+                const groupMangas = groupedMangas.get(group) || [];
+                const section = (
+                  <DateGroupSection
+                    key={group}
+                    group={group}
+                    mangas={groupMangas}
+                    baseIndex={runningIndex}
+                  />
+                );
+                runningIndex += groupMangas.length;
+                return section;
+              })}
+
+              {/* 無限滾動觸發器 */}
+              <div ref={loaderRef} className="flex h-20 items-center justify-center">
+                {loadingMore && (
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                    <span>載入更多...</span>
+                  </div>
+                )}
+                {pagination && page >= pagination.total && mangas.length > 0 && (
+                  <p className="text-sm text-muted-foreground">已載入全部更新</p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </main>
-    </div>
+    </>
   );
 }

--- a/src/app/update/error.tsx
+++ b/src/app/update/error.tsx
@@ -16,7 +16,7 @@ export default function UpdateError({ error, reset }: ErrorProps) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4" role="alert">
       <AlertCircle className="h-12 w-12 text-destructive" />
       <h2 className="text-xl font-serif font-medium">載入最新更新失敗</h2>
       <p className="max-w-md text-center text-sm text-muted-foreground">{error.message}</p>

--- a/src/app/update/loading.tsx
+++ b/src/app/update/loading.tsx
@@ -2,8 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function UpdateLoading() {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-4 py-8">
+    <div className="mx-auto max-w-7xl px-4 py-8">
         {/* 標題骨架 */}
         <Skeleton className="mb-6 h-8 w-32" />
 
@@ -23,6 +22,5 @@ export default function UpdateLoading() {
           </div>
         ))}
       </div>
-    </div>
   );
 }

--- a/src/components/DesignThemeProvider.tsx
+++ b/src/components/DesignThemeProvider.tsx
@@ -9,23 +9,18 @@ import {
 import { DesignThemeContext } from '@/lib/hooks/useDesignTheme';
 
 export function DesignThemeProvider({ children }: { children: React.ReactNode }) {
-  const [designTheme, setDesignThemeState] = useState<DesignTheme>(DEFAULT_DESIGN_THEME);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
+  const [designTheme, setDesignThemeState] = useState<DesignTheme>(() => {
+    if (typeof window === 'undefined') return DEFAULT_DESIGN_THEME;
     const stored = localStorage.getItem(DESIGN_THEME_STORAGE_KEY);
     if (stored && Object.values(DesignTheme).includes(stored as DesignTheme)) {
-      setDesignThemeState(stored as DesignTheme);
+      return stored as DesignTheme;
     }
-    setIsLoaded(true);
-  }, []);
-
+    return DEFAULT_DESIGN_THEME;
+  });
   useEffect(() => {
     document.documentElement.setAttribute('data-design-theme', designTheme);
-    if (isLoaded) {
-      localStorage.setItem(DESIGN_THEME_STORAGE_KEY, designTheme);
-    }
-  }, [designTheme, isLoaded]);
+    localStorage.setItem(DESIGN_THEME_STORAGE_KEY, designTheme);
+  }, [designTheme]);
 
   const setDesignTheme = useCallback((theme: DesignTheme) => {
     setDesignThemeState(theme);

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import type { LucideIcon } from 'lucide-react';
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  message: string;
+  actionLabel?: string;
+  actionHref?: string;
+  onAction?: () => void;
+}
+
+export function EmptyState({ icon: Icon, message, actionLabel, actionHref, onAction }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <Icon className="h-16 w-16 text-muted-foreground/30" />
+      <p className="text-lg text-muted-foreground">{message}</p>
+      {actionLabel && actionHref && (
+        <Button asChild variant="outline">
+          <Link href={actionHref}>{actionLabel}</Link>
+        </Button>
+      )}
+      {actionLabel && onAction && !actionHref && (
+        <Button onClick={onAction} variant="outline">{actionLabel}</Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/FavoritesSection.tsx
+++ b/src/components/FavoritesSection.tsx
@@ -24,5 +24,5 @@ export default function FavoritesSection() {
     return null;
   }
 
-  return <StackedCardList items={items} title="我的收藏" />;
+  return <StackedCardList items={items} title="我的收藏" viewAllHref="/favorites" />;
 }

--- a/src/components/HistorySection.tsx
+++ b/src/components/HistorySection.tsx
@@ -34,6 +34,7 @@ export default function HistorySection() {
     <StackedCardList
       items={items}
       title="最近閱讀"
+      viewAllHref="/history"
       titleExtra={
         <button
           onClick={clearHistory}

--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Star, Clock } from 'lucide-react';
@@ -18,7 +19,7 @@ interface MangaCardProps {
  * 漫畫卡片元件
  * 精緻暗色風格，支援 3D 傾斜效果、微光邊框和滑入動畫
  */
-export default function MangaCard({ manga, animationDelay = 0 }: MangaCardProps) {
+const MangaCard = memo(function MangaCard({ manga, animationDelay = 0 }: MangaCardProps) {
   const coverUrl = getProxiedImageUrl(manga.cover);
 
   return (
@@ -27,10 +28,10 @@ export default function MangaCard({ manga, animationDelay = 0 }: MangaCardProps)
       className="group block outline-none"
       aria-label={`閱讀 ${manga.name}，最新章節：${manga.latestChapter}`}
     >
-      {/* 卡片容器：微光邊框效果 */}
-      <div className="relative rounded-xl p-[1px] transition-all duration-300 bg-gradient-to-br from-border/50 via-border/20 to-border/50 group-hover:from-primary/60 group-hover:via-primary/30 group-hover:to-primary/60 group-focus-visible:from-primary/60 group-focus-visible:via-primary/30 group-focus-visible:to-primary/60 group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-background">
+      {/* 卡片容器：ring 邊框效果 */}
+      <div className="relative rounded-xl transition-all duration-300 ring-1 ring-border/30 group-hover:ring-primary/50 group-focus-visible:ring-2 group-focus-visible:ring-primary group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-background">
         {/* 3D 傾斜效果 */}
-        <TiltCard animationDelay={animationDelay} className="aspect-[3/4] overflow-hidden rounded-[11px]">
+        <TiltCard animationDelay={animationDelay} className="aspect-[3/4] overflow-hidden rounded-xl">
           <div className="relative h-full w-full overflow-hidden">
             {/* 封面圖片 */}
             <Image
@@ -53,33 +54,17 @@ export default function MangaCard({ manga, animationDelay = 0 }: MangaCardProps)
               </div>
             )}
 
-            {/* 底部漸層遮罩 + 資訊區 */}
-            <div className="absolute inset-x-0 bottom-0 z-20 translate-y-2 opacity-0 transition-all duration-300 ease-out group-hover:translate-y-0 group-hover:opacity-100">
-              {/* 漸層背景 */}
-              <div className="absolute inset-0 bg-gradient-to-t from-black via-black/80 to-transparent" />
-
-              {/* 資訊內容 */}
-              <div className="relative space-y-1.5 p-3 pt-8">
-                {/* 最新章節 */}
-                <p className="truncate text-sm font-medium text-white">
-                  {manga.latestChapter}
-                </p>
-
-                {/* 更新時間 */}
-                {manga.updateTime && (
-                  <div className="flex items-center gap-1 text-white/60">
-                    <Clock className="h-3 w-3" />
-                    <span className="text-xs">{manga.updateTime}</span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* 預設顯示的漸層（hover 前） */}
-            <div className="absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/60 to-transparent p-3 transition-opacity duration-300 group-hover:opacity-0">
-              <p className="truncate text-xs text-white/80">
+            {/* 底部資訊 — 章節名永遠可見，更新時間 hover 展開 */}
+            <div className="absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-black/70 via-black/40 to-transparent p-3 pt-8">
+              <p className="truncate text-sm font-medium text-white">
                 {manga.latestChapter}
               </p>
+              {manga.updateTime && (
+                <div className="flex items-center gap-1 text-white/60 max-h-0 overflow-hidden transition-all duration-300 group-hover:max-h-8 group-hover:mt-1">
+                  <Clock className="h-3 w-3" />
+                  <span className="text-xs">{manga.updateTime}</span>
+                </div>
+              )}
             </div>
           </div>
         </TiltCard>
@@ -91,4 +76,6 @@ export default function MangaCard({ manga, animationDelay = 0 }: MangaCardProps)
       </h3>
     </Link>
   );
-}
+});
+
+export default MangaCard;

--- a/src/components/Navbar/MobileMenu.tsx
+++ b/src/components/Navbar/MobileMenu.tsx
@@ -2,35 +2,27 @@
 
 /**
  * 手機版選單元件
+ * 導航項目已在 navbar 本體顯示，此處僅提供搜尋功能
  */
 
-import Link from 'next/link';
-import { Search, Clock, Heart } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { NAV_ITEMS, NAV_ACTIVE_CLASS, type NavItem } from './types';
 
 interface MobileMenuProps {
   isOpen: boolean;
-  pathname: string;
   searchValue: string;
-  historyCount: number;
   onSearchChange: (value: string) => void;
   onSearchSubmit: (e: React.FormEvent) => void;
   onClose: () => void;
-  isActiveNavItem: (item: NavItem) => boolean;
 }
 
 export function MobileMenu({
   isOpen,
-  pathname,
   searchValue,
-  historyCount,
   onSearchChange,
   onSearchSubmit,
   onClose,
-  isActiveNavItem,
 }: MobileMenuProps) {
   return (
     <div
@@ -45,7 +37,12 @@ export function MobileMenu({
       )}
     >
       {/* 手機版搜尋框 */}
-      <form onSubmit={onSearchSubmit} className="mb-3">
+      <form
+        onSubmit={(e) => {
+          onSearchSubmit(e);
+          onClose();
+        }}
+      >
         <div className="relative">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -57,75 +54,6 @@ export function MobileMenu({
           />
         </div>
       </form>
-
-      {/* 手機版導航連結 */}
-      <div className="space-y-1">
-        {NAV_ITEMS.map((item) => {
-          const isActive = isActiveNavItem(item);
-          const Icon = item.icon;
-
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onClose}
-              className={cn(
-                'flex items-center gap-3 px-4 py-2.5',
-                'rounded-full text-sm font-medium',
-                'transition-all duration-200',
-                isActive
-                  ? NAV_ACTIVE_CLASS
-                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              {item.label}
-            </Link>
-          );
-        })}
-
-        {/* 分隔線 */}
-        <div className="my-2 h-px bg-border/50" />
-
-        {/* 閱讀歷史 */}
-        <Link
-          href="/history"
-          onClick={onClose}
-          className={cn(
-            'flex items-center gap-3 px-4 py-2.5',
-            'rounded-full text-sm font-medium',
-            'transition-all duration-200',
-            pathname.startsWith('/history')
-              ? NAV_ACTIVE_CLASS
-              : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-          )}
-        >
-          <Clock className="h-4 w-4" />
-          閱讀歷史
-          {historyCount > 0 && (
-            <Badge variant="secondary" className="ml-auto">
-              {historyCount}
-            </Badge>
-          )}
-        </Link>
-
-        {/* 我的收藏 */}
-        <Link
-          href="/favorites"
-          onClick={onClose}
-          className={cn(
-            'flex items-center gap-3 px-4 py-2.5',
-            'rounded-full text-sm font-medium',
-            'transition-all duration-200',
-            pathname.startsWith('/favorites')
-              ? NAV_ACTIVE_CLASS
-              : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-          )}
-        >
-          <Heart className="h-4 w-4" />
-          我的收藏
-        </Link>
-      </div>
     </div>
   );
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -6,7 +6,7 @@
  * 響應式設計：桌面版水平導航，手機版漢堡選單
  */
 
-import { useState, useCallback, useEffect, Suspense } from 'react';
+import { useState, useCallback, useEffect, Suspense, startTransition } from 'react';
 import Link from 'next/link';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { BookOpen, SlidersHorizontal, Menu, X, Heart, Clock } from 'lucide-react';
@@ -22,7 +22,6 @@ import { DesignThemeToggle } from '@/components/DesignThemeToggle';
 import { FilterContent } from '@/components/MangaFilter';
 import { type FilterState, getActiveFilterCount } from '@/lib/filter-types';
 import { cn } from '@/lib/utils';
-import { useHistory } from '@/lib/hooks/useHistory';
 import { NAV_ITEMS, NAV_ACTIVE_CLASS, type NavItem } from './types';
 import { parseFiltersFromParams, filtersToParams } from './utils';
 import { DesktopSearch } from './DesktopSearch';
@@ -77,7 +76,8 @@ function HoverExpandButton({
       <span
         className={cn(
           'text-sm font-medium whitespace-nowrap overflow-hidden transition-all duration-200',
-          isHovered ? 'w-16 ml-1.5' : 'w-0'
+          'hidden md:inline',
+          isHovered ? 'md:w-16 md:ml-1.5' : 'md:w-0'
         )}
       >
         {label}
@@ -126,9 +126,6 @@ function NavbarContent() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
-  // 閱讀歷史
-  const { history, isLoaded: isHistoryLoaded } = useHistory();
-
   // 從 URL 解析 filter 狀態
   const filters = parseFiltersFromParams(searchParams);
   const activeFilterCount = getActiveFilterCount(filters);
@@ -153,7 +150,9 @@ function NavbarContent() {
   /** 處理搜尋 */
   const handleSearch = useCallback(
     (keyword: string) => {
-      router.push(`/?keyword=${encodeURIComponent(keyword)}`);
+      startTransition(() => {
+        router.push(`/?keyword=${encodeURIComponent(keyword)}`);
+      });
       setIsMobileMenuOpen(false);
     },
     [router]
@@ -173,7 +172,9 @@ function NavbarContent() {
     (newFilters: FilterState) => {
       const params = filtersToParams(newFilters);
       const queryString = params.toString();
-      router.push(queryString ? `/?${queryString}` : '/');
+      startTransition(() => {
+        router.push(queryString ? `/?${queryString}` : '/');
+      });
     },
     [router]
   );
@@ -183,7 +184,7 @@ function NavbarContent() {
       <div className="mx-auto max-w-7xl px-4">
         <nav
           className={cn(
-            'inline-flex items-center gap-1',
+            'flex md:inline-flex items-center gap-1',
             'rounded-full px-2 py-1.5',
             'border border-border/50',
             'bg-background/80 backdrop-blur-xl',
@@ -191,7 +192,7 @@ function NavbarContent() {
             'shadow-lg shadow-black/5'
           )}
         >
-          <div className="flex items-center">
+          <div className="flex flex-1 items-center md:flex-initial">
             {/* Logo */}
             <Link
               href="/"
@@ -207,10 +208,10 @@ function NavbarContent() {
             </Link>
 
             {/* 分隔線 */}
-            <div className="hidden h-6 w-px bg-border/50 md:block" />
+            <div className="h-6 w-px bg-border/50" />
 
-            {/* 桌面版導航 */}
-            <div className="relative hidden items-center md:flex">
+            {/* 導航項目 */}
+            <div className="relative flex items-center">
               {NAV_ITEMS.map((item) => (
                 <HoverExpandButton
                   key={item.href}
@@ -222,26 +223,26 @@ function NavbarContent() {
               ))}
             </div>
 
-            {/* 操作區 */}
-            <div className="flex items-center">
-              {/* 閱讀歷史 */}
-              <HoverExpandButton
-                icon={Clock}
-                label="閱讀歷史"
-                href="/history"
-                isActive={pathname.startsWith('/history')}
-              />
+            {/* 閱讀歷史 */}
+            <HoverExpandButton
+              icon={Clock}
+              label="閱讀歷史"
+              href="/history"
+              isActive={pathname.startsWith('/history')}
+            />
 
-              {/* 我的收藏 */}
-              <HoverExpandButton
-                icon={Heart}
-                label="我的收藏"
-                href="/favorites"
-                isActive={pathname.startsWith('/favorites')}
-              />
+            {/* 我的收藏 */}
+            <HoverExpandButton
+              icon={Heart}
+              label="我的收藏"
+              href="/favorites"
+              isActive={pathname.startsWith('/favorites')}
+            />
 
+            {/* 操作區 — 推到右側 */}
+            <div className="ml-auto flex items-center">
               {/* 分隔線 */}
-              <div className="hidden h-6 w-px bg-border/50 md:block" />
+              <div className="hidden sm:block h-6 w-px bg-border/50" />
 
               {/* 篩選按鈕（僅首頁非搜尋模式顯示） */}
               {isHomePage && !isSearchMode && (
@@ -251,7 +252,7 @@ function NavbarContent() {
                       variant="ghost"
                       size="icon"
                       className={cn(
-                        'relative h-8 w-8 rounded-full',
+                        'relative h-10 w-10 rounded-full',
                         activeFilterCount > 0 && 'text-foreground'
                       )}
                       title="篩選"
@@ -267,7 +268,7 @@ function NavbarContent() {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-[360px] p-4" align="end" sideOffset={8}>
+                  <PopoverContent className="w-[min(360px,calc(100vw-2rem))] p-4" align="end" sideOffset={8}>
                     <FilterContent filters={filters} onChange={handleFilterChange} />
                   </PopoverContent>
                 </Popover>
@@ -286,7 +287,7 @@ function NavbarContent() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 rounded-full md:hidden"
+                className="h-10 w-10 rounded-full md:hidden"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                 title={isMobileMenuOpen ? '關閉選單' : '開啟選單'}
               >
@@ -299,13 +300,10 @@ function NavbarContent() {
         {/* 手機版選單 */}
         <MobileMenu
           isOpen={isMobileMenuOpen}
-          pathname={pathname}
           searchValue={searchValue}
-          historyCount={isHistoryLoaded ? history.length : 0}
           onSearchChange={setSearchValue}
           onSearchSubmit={handleMobileSearchSubmit}
           onClose={() => setIsMobileMenuOpen(false)}
-          isActiveNavItem={isActiveNavItem}
         />
       </div>
     </header>
@@ -321,7 +319,7 @@ function NavbarFallback() {
       <div className="mx-auto max-w-7xl px-4">
         <nav
           className={cn(
-            'inline-flex items-center gap-1',
+            'flex md:inline-flex items-center gap-1',
             'rounded-full px-2 py-1.5',
             'border border-border/50',
             'bg-background/80 backdrop-blur-xl',
@@ -340,8 +338,10 @@ function NavbarFallback() {
             <BookOpen className="h-5 w-5 text-primary" />
             <span className="hidden sm:inline font-serif text-primary">Manga</span>
           </Link>
-          <DesignThemeToggle />
-          <ThemeToggle />
+          <div className="ml-auto flex items-center">
+            <DesignThemeToggle />
+            <ThemeToggle />
+          </div>
         </nav>
       </div>
     </header>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { LucideIcon } from 'lucide-react';
+
+interface PageHeaderProps {
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+  count?: number;
+  actions?: React.ReactNode;
+}
+
+export function PageHeader({ icon: Icon, title, subtitle, count, actions }: PageHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <div className="mb-6 flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" className="shrink-0 h-10 w-10" onClick={() => router.back()}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <Icon className="h-6 w-6 text-foreground" />
+        <div>
+          <h1 className="text-2xl font-serif font-medium">{title}</h1>
+          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+        </div>
+        {count !== undefined && count > 0 && (
+          <span className="text-sm text-muted-foreground">({count} 部)</span>
+        )}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/SnowEffect.tsx
+++ b/src/components/SnowEffect.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
+import { usePathname } from "next/navigation";
 
 /**
  * 雪花粒子介面
@@ -29,6 +30,7 @@ export function SnowEffect() {
   const { resolvedTheme } = useTheme();
   const themeRef = useRef(resolvedTheme);
   const colorRef = useRef<string>("218, 165, 32");
+  const pathname = usePathname();
 
   useEffect(() => {
     themeRef.current = resolvedTheme ?? (document.documentElement.classList.contains("dark") ? "dark" : "light");
@@ -47,10 +49,13 @@ export function SnowEffect() {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mql.matches) return;
+
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const SNOWFLAKE_COUNT = 300;
+    const SNOWFLAKE_COUNT = 100;
 
     /**
      * 調整 Canvas 尺寸
@@ -120,8 +125,9 @@ export function SnowEffect() {
       window.removeEventListener("resize", resize);
       cancelAnimationFrame(animationFrameRef.current);
     };
-   
   }, []);
+
+  if (pathname.startsWith("/read/")) return null;
 
   return (
     <canvas

--- a/src/components/SnowEffectLoader.tsx
+++ b/src/components/SnowEffectLoader.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const SnowEffect = dynamic(
+  () => import('@/components/SnowEffect').then((m) => ({ default: m.SnowEffect })),
+  { ssr: false }
+);
+
+export function SnowEffectLoader() {
+  return <SnowEffect />;
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,7 @@
+export function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-foreground border-t-transparent" />
+    </div>
+  );
+}

--- a/src/components/StackedCardList.tsx
+++ b/src/components/StackedCardList.tsx
@@ -11,8 +11,8 @@ const VISIBLE_RATIO = 0.4;
 /** 計算每張卡片的偏移量 */
 const CARD_OFFSET = CARD_WIDTH * VISIBLE_RATIO;
 /** 卡片旋轉角度範圍 */
-const MIN_ROTATE = -2;
-const MAX_ROTATE = 7;
+const MIN_ROTATE = -1;
+const MAX_ROTATE = 4;
 /** hover 時左右讓開的距離 */
 const SPREAD_DISTANCE = CARD_WIDTH * 0.5;
 
@@ -43,6 +43,8 @@ interface StackedCardListProps {
   title: string;
   /** 標題右側額外元素 */
   titleExtra?: React.ReactNode;
+  /** 查看全部連結 */
+  viewAllHref?: string;
 }
 
 /** 單張卡片圖片元件 */
@@ -133,9 +135,7 @@ function DesktopStackedCards({ items }: { items: StackedCardItem[] }) {
                 left: `${index * CARD_OFFSET}px`,
                 zIndex: isHovered ? 50 : index,
                 transform: `translateX(${translateX}px) rotate(${isHovered ? 0 : getRotateAngle(index)}deg)`,
-                filter: hoveredIndex !== null && index > hoveredIndex
-                  ? 'brightness(1.35) saturate(0.4) grayscale(0.3)'
-                  : undefined,
+                filter: undefined,
               }}
               onMouseEnter={() => setHoveredIndex(index)}
             >
@@ -164,7 +164,7 @@ function DesktopStackedCards({ items }: { items: StackedCardItem[] }) {
  * 桌面版：卡片像書本一樣堆疊，hover 時左右讓開
  * 手機版：水平滾動 carousel
  */
-export default function StackedCardList({ items, title, titleExtra }: StackedCardListProps) {
+export default function StackedCardList({ items, title, titleExtra, viewAllHref }: StackedCardListProps) {
   if (items.length === 0) {
     return null;
   }
@@ -175,6 +175,11 @@ export default function StackedCardList({ items, title, titleExtra }: StackedCar
       <div className="mb-1 flex items-center gap-2">
         <h2 className="text-lg font-serif font-medium">{title}</h2>
         {titleExtra}
+        {viewAllHref && (
+          <Link href={viewAllHref} className="ml-auto text-sm text-muted-foreground hover:text-primary transition-colors">
+            查看全部 ›
+          </Link>
+        )}
       </div>
 
       {/* 手機版 Carousel */}

--- a/src/components/TiltCard.tsx
+++ b/src/components/TiltCard.tsx
@@ -29,8 +29,7 @@ export default function TiltCard({
   className = '',
 }: TiltCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
-  const [transform, setTransform] = useState('perspective(1000px) rotateX(0deg) rotateY(0deg)');
-  const [shineStyle, setShineStyle] = useState({ backgroundPosition: '0% 0%', opacity: 0 });
+  const shineRef = useRef<HTMLDivElement>(null);
   const [isHovering, setIsHovering] = useState(false);
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -45,15 +44,14 @@ export default function TiltCard({
     const rotateX = ((y - centerY) / centerY) * -MAX_TILT_ANGLE;
     const rotateY = ((x - centerX) / centerX) * MAX_TILT_ANGLE;
 
-    setTransform(`perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(${HOVER_SCALE})`);
+    cardRef.current.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(${HOVER_SCALE})`;
 
-    // 計算反光位置（根據滑鼠位置移動）
-    const shineX = (x / rect.width) * 100;
-    const shineY = (y / rect.height) * 100;
-    setShineStyle({
-      backgroundPosition: `${shineX}% ${shineY}%`,
-      opacity: 1,
-    });
+    if (shineRef.current) {
+      const percentX = (x / rect.width) * 100;
+      const percentY = (y / rect.height) * 100;
+      shineRef.current.style.background = `radial-gradient(circle at ${percentX}% ${percentY}%, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.1) 20%, transparent 50%)`;
+      shineRef.current.style.opacity = '1';
+    }
   }, []);
 
   const handleMouseEnter = useCallback(() => {
@@ -62,8 +60,12 @@ export default function TiltCard({
 
   const handleMouseLeave = useCallback(() => {
     setIsHovering(false);
-    setTransform('perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)');
-    setShineStyle({ backgroundPosition: '50% 50%', opacity: 0 });
+    if (cardRef.current) {
+      cardRef.current.style.transform = '';
+    }
+    if (shineRef.current) {
+      shineRef.current.style.opacity = '0';
+    }
   }, []);
 
   const entranceClass = enableEntrance
@@ -78,7 +80,6 @@ export default function TiltCard({
       onMouseLeave={handleMouseLeave}
       className={`${entranceClass} ${className}`}
       style={{
-        transform,
         transition: isHovering ? 'none' : 'transform 0.3s ease-out',
         transformStyle: 'preserve-3d',
         animationDelay: enableEntrance ? `${animationDelay}ms` : undefined,
@@ -86,13 +87,9 @@ export default function TiltCard({
     >
       {/* 3D 傾斜反光效果 */}
       <div
+        ref={shineRef}
         className="pointer-events-none absolute inset-0 z-10 rounded-lg transition-opacity duration-200"
-        style={{
-          background: 'radial-gradient(circle at var(--shine-x, 50%) var(--shine-y, 50%), rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.1) 20%, transparent 50%)',
-          backgroundSize: '150% 150%',
-          backgroundPosition: shineStyle.backgroundPosition,
-          opacity: shineStyle.opacity,
-        }}
+        style={{ opacity: 0 }}
       />
       {children}
     </div>

--- a/src/components/reader/Reader.tsx
+++ b/src/components/reader/Reader.tsx
@@ -28,7 +28,7 @@ import { getProxiedImageUrl } from '@/lib/image-utils';
  */
 function LoadingState() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
+    <div className="flex min-h-screen items-center justify-center">
       <div className="space-y-4 text-center">
         <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-foreground border-t-transparent" />
         <p className="text-sm text-muted-foreground">載入中...</p>
@@ -42,7 +42,7 @@ function LoadingState() {
  */
 function ErrorState({ mangaId, error }: { mangaId: number; error: string }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4">
       <div className="text-xl text-destructive">{error}</div>
       <Button asChild variant="secondary">
         <Link href={`/manga/${mangaId}`}>返回漫畫詳情</Link>
@@ -608,7 +608,7 @@ export default function Reader({ mangaId, chapterId, initialData }: ReaderProps)
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <>
       {/* 頂部工具列 */}
       <TopToolbar mangaId={mangaId} data={data} isVisible={isVisible} />
 
@@ -661,6 +661,6 @@ export default function Reader({ mangaId, chapterId, initialData }: ReaderProps)
         isOpen={showShortcuts}
         onClose={() => setShowShortcuts(false)}
       />
-    </div>
+    </>
   );
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,3 +7,6 @@ export const STAGGER_DELAY = 50;
 
 /** 堆疊卡片最多顯示數量 */
 export const MAX_STACKED_CARDS = 10;
+
+/** 密集漫畫封面網格 class（收藏、歷史等頁面用） */
+export const DENSE_GRID_CLASS = 'grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8';


### PR DESCRIPTION
## Summary
- **共用元件抽取**：`PageHeader`、`EmptyState`、`Spinner`、`SnowEffectLoader` 消除跨頁面重複 UI 模式
- **效能優化**：`MangaCard`/`RankItemCard` 加 `memo()`、`TiltCard`/`Reader`/`SnowEffect` 改 `dynamic()` lazy load、TiltCard 以 ref 取代 state 避免每幀 re-render
- **Layout 集中化**：`min-h-screen bg-background pt-20` 移至 `layout.tsx`，各頁面移除重複外殼
- **UX 強化**：首頁 IntersectionObserver 無限滾動、收藏/歷史新增管理模式、漫畫詳情改 `router.back()`、手機版 Navbar 全導航可見、`aria-live`/`role="alert"` 無障礙標記、新增 `not-found.tsx`
- **程式碼整理**：`DENSE_GRID_CLASS` 常數化、`MangaGridSkeleton` 抽取、SnowEffect 降至 100 粒子 + `prefers-reduced-motion` 支援

## Test plan
- [x] `npm run build` 通過
- [ ] 首頁瀏覽、搜尋、篩選正常
- [ ] 無限滾動正確觸發載入更多
- [ ] 收藏頁/歷史頁管理模式可切換，刪除功能正常
- [ ] 漫畫詳情頁「返回」按鈕回到上一頁
- [ ] 排行榜切換榜單正常
- [ ] 最新更新頁面載入與無限滾動正常
- [ ] 閱讀器開啟/操作正常
- [ ] 手機版導航列所有連結可點擊

🤖 Generated with [Claude Code](https://claude.com/claude-code)